### PR TITLE
Edit on "Other Limits"

### DIFF
--- a/server-limits.md
+++ b/server-limits.md
@@ -32,7 +32,7 @@ The amount of emojis (Both normal and animated ones) a Server can have can chang
 - Reactions per message: **20** reactions.
 - Maximum attachment size
   - Default: **8 MB (or 8388608 bytes)**.
-  - On Boost-Level 2: **50 MB (or 52428800 bytes)**
+  - On Boost-Level 2 or when having Nitro Classic: **50 MB (or 52428800 bytes)**
   - On Boost-Level 3 or when having Nitro: **100 MB (or 104857600 bytes)**
 - Minimum time for idling: **10 minutes**.
 - Username/nickname: **32 characters**.


### PR DESCRIPTION
Nitro Classic users also receive 50MB attachment size limit, as stated here: https://support.discord.com/hc/en-us/articles/115000435108-Discord-Nitro-Classic-Nitro